### PR TITLE
Correctly indent splicing reader conditionals

### DIFF
--- a/clj/dev-resources/test-reader-conditional-indent.in
+++ b/clj/dev-resources/test-reader-conditional-indent.in
@@ -7,4 +7,7 @@
       (-to-date-time [x]
         (goog.date.UtcDateTime. (.getYear x) (.getMonth x) (.getDate x)))))
 
+#?@(:clj  [5 6 7 8]
+      :cljs [1 2 3 4])))
+
 ;; vim:ft=clojure:

--- a/clj/dev-resources/test-reader-conditional-indent.out
+++ b/clj/dev-resources/test-reader-conditional-indent.out
@@ -7,4 +7,7 @@
      (-to-date-time [x]
        (goog.date.UtcDateTime. (.getYear x) (.getMonth x) (.getDate x)))))
 
+#?@(:clj  [5 6 7 8]
+    :cljs [1 2 3 4])))
+
 ;; vim:ft=clojure:

--- a/indent/clojure.vim
+++ b/indent/clojure.vim
@@ -215,9 +215,10 @@ if exists("*searchpairpos")
 	endfunction
 
 	" Check if form is a reader conditional, that is, it is prefixed by #?
-	" or @#?
+	" or #?@
 	function! s:is_reader_conditional_special_case(position)
 		return getline(a:position[0])[a:position[1] - 3 : a:position[1] - 2] == "#?"
+			\|| getline(a:position[0])[a:position[1] - 4 : a:position[1] - 2] == "#?@"
 	endfunction
 
 	" Returns 1 for opening brackets, -1 for _anything else_.


### PR DESCRIPTION
Adjusts `is_reader_conditional_special_case` to also match splices, i.e. `#?@`. The test case is taken from https://clojure.org/guides/reader_conditionals

Without this, splicing conditionals are indented as functions, e.g.

```clj
 #?@(:clj  [5 6 7 8]
           :cljs [1 2 3 4])))
```