### PR TITLE
Allow "percent" character in keywords

### DIFF
--- a/syntax/clojure.vim
+++ b/syntax/clojure.vim
@@ -68,7 +68,7 @@ delfunction s:syntax_keyword
 "   * Must not end in a : or /
 "   * Must not have two adjacent colons except at the beginning
 "   * Must not contain any reader metacharacters except for ' and #
-syntax match clojureKeyword "\v<:{1,2}%([^ \n\r\t()\[\]{}";@^`~\\%/]+/)*[^ \n\r\t()\[\]{}";@^`~\\%/]+:@1<!>"
+syntax match clojureKeyword "\v<:{1,2}([^ \n\r\t()\[\]{}";@^`~\\/]+/)*[^ \n\r\t()\[\]{}";@^`~\\/]+:@1<!>"
 
 syntax match clojureStringEscape "\v\\%([\\btnfr"]|u\x{4}|[0-3]\o{2}|\o{1,2})" contained
 


### PR DESCRIPTION
This PR syntax highlights keywords containing "percent" characters.

The [clojure.data.xml](https://github.com/clojure/data.xml) library converts XML namespaces into keywords containing "percent" characters.

| Before | After |
|---|---|
| <img src="https://user-images.githubusercontent.com/26504626/117123022-69fbc100-ad8e-11eb-97de-6289570aa289.png" width=400 /> | <img src="https://user-images.githubusercontent.com/26504626/117122876-40db3080-ad8e-11eb-97d5-2fcf1a11a631.png" width=400 /> |