### PR TITLE
Keyword and Symbol prefix matching

### DIFF
--- a/clj/test/vim/syntax_test.clj
+++ b/clj/test/vim/syntax_test.clj
@@ -9,9 +9,27 @@
 
 (defpredicates number :clojureNumber)
 (def-eq-predicates kw [:clojureKeywordNsColon :clojureKeyword])
-(def-eq-predicates kwWithNs [:clojureKeywordNsColon :clojureKeyword])
-(def-eq-predicates sym [:clojureSymbolNsColon :clojureSymbol])
-(def-eq-predicates symWithNs [:clojureSymbolNsColon :clojureSymbol])
+(def-eq-predicates kwCurrentNs [:clojureKeywordNsColon :clojureKeywordNsColon :clojureKeyword])
+(def-eq-predicates kwWithNs [:clojureKeywordNsColon :clojureKeywordNs :clojureKeywordNsSeparator :clojureKeyword])
+(def-eq-predicates kwWithNs3_4 [:clojureKeywordNsColon
+                                :clojureKeywordNs
+                                :clojureKeywordNs
+                                :clojureKeywordNs
+                                :clojureKeywordNsSeparator
+                                :clojureKeyword
+                                :clojureKeyword
+                                :clojureKeyword
+                                :clojureKeyword])
+(def-eq-predicates sym [:clojureSymbol])
+(def-eq-predicates symWithNs [:clojureSymbol])
+(def-eq-predicates symWithNs_tripleBody [:clojureKeywordNsColon
+                                         :clojureKeywordNs :clojureKeywordNsSeparator
+                                         :clojureKeywordNs :clojureKeywordNsSeparator
+                                         :clojureKeywordNs :clojureKeywordNsSeparator
+                                         :clojureKeyword])
+(def-eq-predicates kwWithNamedNs [:clojureKeywordNsColon :clojureKeywordNsColon
+                                  :clojureKeywordNs :clojureKeywordNsSeparator :clojureKeyword])
+
 (defpredicates character :clojureCharacter)
 (defpredicates regexp :clojureRegexp)
 (defpredicates regexp-delimiter :clojureRegexpDelimiter)
@@ -111,28 +129,24 @@
 
 (comment (test #'test-character-literals))
 
+(def emptyKeyword (keyword ""))
+
 (defsyntaxtest keywords-test
   ["%s"
    [":1" kw
     ":A" kw
     ":a" kw
-    ":αβγ" kw
-    "::a" kw
+    ":αβγ" (partial = [:clojureKeywordNsColon :clojureKeyword :clojureKeyword :clojureKeyword])
+    "::a" kwCurrentNs
     ":a/b" kwWithNs
-    ":a:b" kw
-    ":a:b/:c:b" kwWithNs
-    ":a/b/c/d" kwWithNs
-    "::a/b" kwWithNs
-    "::" !kw
-    "::" !kwWithNs
-    ":a:" !kw
-    ":a:" !kwWithNs
-    ":a/" !kw
-    ":a/" !kwWithNs
-    ":/" !kw       ; This is legal, but for simplicity we do not match it
-    ":/" !kwWithNs ; This is legal, but for simplicity we do not match it
-    ":" !kw
-    ":" !kwWithNs]])
+    ":a:b/:c:b" kwWithNs3_4
+    ":a/b/c/d" symWithNs_tripleBody
+    "::a/b" kwWithNamedNs
+    "::" (partial = [emptyKeyword emptyKeyword])
+    ":a:" (partial = [emptyKeyword :clojureSymbol emptyKeyword])
+    ":a/" (partial = [:clojureKeywordNsColon :clojureKeywordNs :clojureKeywordNsSeparator])
+    ":/" (partial =  [:clojureKeywordNsColon :clojureKeywordNsSeparator])
+    ":" (partial = [emptyKeyword])]])
 
 (defsyntaxtest symbols-test
   ["%s"
@@ -140,16 +154,26 @@
     "1" !symWithNs
     "A" sym
     "a" sym
-    "αβγ" sym
-    "a/b" symWithNs
-    "a:b" sym
-    "a:b/:c:b" symWithNs
-    "a/b/c/d" symWithNs
+    "αβγ" (partial = [:clojureSymbol :clojureSymbol :clojureSymbol])
+    "a/b" (partial = [:clojureSymbolNs :clojureSymbolNsSeparator :clojureSymbol])
+    "a:b" (partial = [:clojureSymbol :clojureSymbol :clojureSymbol])
+    "a:b/:c:b" (partial = [:clojureSymbolNs
+                           :clojureSymbolNs
+                           :clojureSymbolNs
+                           :clojureSymbolNsSeparator
+                           :clojureSymbol
+                           :clojureSymbol
+                           :clojureSymbol
+                           :clojureSymbol])
+    "a/b/c/d" (partial = [:clojureSymbolNs :clojureSymbolNsSeparator
+                          :clojureSymbolNs :clojureSymbolNsSeparator
+                          :clojureSymbolNs :clojureSymbolNsSeparator
+                          :clojureSymbol])
     "a:" !sym
     "a:" !symWithNs
     "a/" !sym
     "a/" !symWithNs
-    "/" sym]])
+    "/" !sym]])
 
 (comment (test #'keywords-test))
 

--- a/clj/test/vim/syntax_test.clj
+++ b/clj/test/vim/syntax_test.clj
@@ -173,7 +173,15 @@
                           :clojureKeywordNs
                           :clojureKeywordNsSeparator
                           :clojureKeyword
-                          :clojureParen])]])
+                          :clojureParen])
+    ":a[:b/c]" (partial = [:clojureKeywordNsColon
+                           :clojureKeyword
+                           :clojureParen
+                           :clojureKeywordNsColon
+                           :clojureKeywordNs
+                           :clojureKeywordNsSeparator
+                           :clojureKeyword
+                           :clojureParen])]])
 
 (defsyntaxtest symbols-test
   ["%s"
@@ -207,7 +215,13 @@
                          :clojureSymbolNs
                          :clojureSymbolNsSeparator
                          :clojureSymbol
-                         :clojureParen])]])
+                         :clojureParen])
+    "#'a/b" (partial = [:clojureDispatch
+                        :clojureDispatch
+                        :clojureSymbolNs
+                        :clojureSymbolNsSeparator
+                        :clojureSymbol
+                        :clojureParen])]])
 
 (comment (test #'keywords-test))
 

--- a/clj/test/vim/syntax_test.clj
+++ b/clj/test/vim/syntax_test.clj
@@ -29,7 +29,27 @@
                                          :clojureKeyword])
 (def-eq-predicates kwWithNamedNs [:clojureKeywordNsColon :clojureKeywordNsColon
                                   :clojureKeywordNs :clojureKeywordNsSeparator :clojureKeyword])
-
+(def-eq-predicates dispatchWithSymbolInside [:clojureDispatch
+                                             :clojureSymbol
+                                             :clojureSymbol
+                                             :clojureSymbol
+                                             :clojureSymbol
+                                             :clojureSymbol
+                                             :clojureSymbol
+                                             :clojureSymbol
+                                             :clojureSymbol
+                                             :clojureParen
+                                             :clojureSymbolNs
+                                             :clojureSymbolNs
+                                             :clojureSymbolNs
+                                             :clojureSymbolNs
+                                             :clojureSymbolNsSeparator
+                                             :clojureSymbol
+                                             :clojureSymbol
+                                             :clojureSymbol
+                                             :clojureSymbol
+                                             :clojureSymbol
+                                             :clojureParen])
 (defpredicates character :clojureCharacter)
 (defpredicates regexp :clojureRegexp)
 (defpredicates regexp-delimiter :clojureRegexpDelimiter)
@@ -173,7 +193,8 @@
     "a:" !symWithNs
     "a/" !sym
     "a/" !symWithNs
-    "/" !sym]])
+    "/" !sym
+    "#function[test/hello]" dispatchWithSymbolInside]])
 
 (comment (test #'keywords-test))
 

--- a/clj/test/vim/syntax_test.clj
+++ b/clj/test/vim/syntax_test.clj
@@ -166,7 +166,14 @@
     ":a:" (partial = [emptyKeyword :clojureSymbol emptyKeyword])
     ":a/" (partial = [:clojureKeywordNsColon :clojureKeywordNs :clojureKeywordNsSeparator])
     ":/" (partial =  [:clojureKeywordNsColon :clojureKeywordNsSeparator])
-    ":" (partial = [emptyKeyword])]])
+    ":" (partial = [emptyKeyword])
+    "a[:b/c]" (partial = [:clojureSymbol
+                          :clojureParen
+                          :clojureKeywordNsColon
+                          :clojureKeywordNs
+                          :clojureKeywordNsSeparator
+                          :clojureKeyword
+                          :clojureParen])]])
 
 (defsyntaxtest symbols-test
   ["%s"
@@ -194,7 +201,13 @@
     "a/" !sym
     "a/" !symWithNs
     "/" !sym
-    "#function[test/hello]" dispatchWithSymbolInside]])
+    "#function[test/hello]" dispatchWithSymbolInside
+    "a[b/c]" (partial = [:clojureSymbol
+                         :clojureParen
+                         :clojureSymbolNs
+                         :clojureSymbolNsSeparator
+                         :clojureSymbol
+                         :clojureParen])]])
 
 (comment (test #'keywords-test))
 

--- a/clj/test/vim/syntax_test.clj
+++ b/clj/test/vim/syntax_test.clj
@@ -220,8 +220,7 @@
                         :clojureDispatch
                         :clojureSymbolNs
                         :clojureSymbolNsSeparator
-                        :clojureSymbol
-                        :clojureParen])]])
+                        :clojureSymbol])]])
 
 (comment (test #'keywords-test))
 

--- a/clj/test/vim/test.clj
+++ b/clj/test/vim/test.clj
@@ -97,12 +97,12 @@
   `(do
      (defn ~sym
        ~(str "Returns true if all elements of coll equal " kw)
-       {:arglists '~'[coll]}
+       {:arglists (list '~'[coll])}
        [coll#]
        (~pred-eq ~kw coll#))
      (defn ~(symbol (str \! sym))
        ~(str "Returns true if any elements of coll do not equal " kw)
-       {:arglists '~'[coll]}
+       {:arglists (list '~'[coll])}
        [coll#]
        (~pred-neq ~kw coll#))))
 
@@ -118,7 +118,7 @@
   "Create two complementary predicate vars, `sym` and `!sym`, which test if
    input and result are equal"
   [sym kw]
-  `(defpredicates-general '= 'not= ~sym ~kw))
+  `(defpredicates-general = not= ~sym ~kw))
 
 (defn benchmark [n file buf & exprs]
   (vim-exec file buf (format "Benchmark(%d, %s)"

--- a/syntax/clojure.vim
+++ b/syntax/clojure.vim
@@ -62,7 +62,7 @@ endif
 unlet! s:key
 delfunction s:syntax_keyword
 
-syntax match clojureKeywordNs contained "\v[^/ :']+\ze/"
+syntax match clojureKeywordNs contained "\v[^/: ']+[^/ ']*\ze/"
 syntax match clojureKeywordNsSeparator contained "/"
 syntax match clojureKeywordNsColon contained "\v<:{1,2}"
 " Keywords are symbols:
@@ -71,7 +71,7 @@ syntax match clojureKeywordNsColon contained "\v<:{1,2}"
 "   * Must not end in a : or /
 "   * Must not have two adjacent colons except at the beginning
 "   * Must not contain any reader metacharacters except for ' and #
-syntax match clojureKeyword "\v<:{1,2}([^ \n\r\t()\[\]{}";@^`~\\/]+/)*[^ \n\r\t()\[\]{}";@^`~\\/]+:@1<!>" contains=clojureKeywordNs,clojureKeywordNsSeparator,clojureKeywordNsColon
+syntax match clojureKeyword "\v<:{1,2}([^ \n\r\t()\[\]{}";@^`~\\/]*/)*[^ \n\r\t()\[\]{}";@^`~\\/]*:@1<!>" contains=clojureKeywordNs,clojureKeywordNsSeparator,clojureKeywordNsColon
 
 syntax match clojureStringEscape "\v\\%([\\btnfr"]|u\x{4}|[0-3]\o{2}|\o{1,2})" contained
 
@@ -79,7 +79,7 @@ syntax region clojureString matchgroup=clojureStringDelimiter start=/"/ skip=/\\
 
 syntax match clojureCharacter "\v\\%(o%([0-3]\o{2}|\o{1,2})|u\x{4}|newline|tab|space|return|backspace|formfeed|.)"
 
-syntax match clojureSymbolNs contained "\v[^/ :']+\ze/"
+syntax match clojureSymbolNs contained "\v[^/ ]+\ze/"
 syntax match clojureSymbolNsSeparator contained "/"
 syntax match clojureSymbol "\v%([a-zA-Z!$&*_+=|<.>?-]|[^\x00-\x7F])+%(:?%([a-zA-Z0-9!#$%&*_+=|'<.>/?-]|[^\x00-\x7F]))*[#:]@1<!" contains=clojureSymbolNs,clojureSymbolNsSeparator
 

--- a/syntax/clojure.vim
+++ b/syntax/clojure.vim
@@ -79,7 +79,7 @@ syntax region clojureString matchgroup=clojureStringDelimiter start=/"/ skip=/\\
 
 syntax match clojureCharacter "\v\\%(o%([0-3]\o{2}|\o{1,2})|u\x{4}|newline|tab|space|return|backspace|formfeed|.)"
 
-syntax match clojureSymbolNs contained "\v[^/ ]+\ze/"
+syntax match clojureSymbolNs contained "\v[^/\[ ]+\ze/"
 syntax match clojureSymbolNsSeparator contained "/"
 syntax match clojureSymbol "\v%([a-zA-Z!$&*_+=|<.>?-]|[^\x00-\x7F])+%(:?%([a-zA-Z0-9!#$%&*_+=|'<.>/?-]|[^\x00-\x7F]))*[#:]@1<!" contains=clojureSymbolNs,clojureSymbolNsSeparator
 

--- a/syntax/clojure.vim
+++ b/syntax/clojure.vim
@@ -79,7 +79,7 @@ syntax region clojureString matchgroup=clojureStringDelimiter start=/"/ skip=/\\
 
 syntax match clojureCharacter "\v\\%(o%([0-3]\o{2}|\o{1,2})|u\x{4}|newline|tab|space|return|backspace|formfeed|.)"
 
-syntax match clojureSymbolNs contained "\v[^/\[ ]+\ze/"
+syntax match clojureSymbolNs contained "\v[^/\[\(\{ ]+\ze/"
 syntax match clojureSymbolNsSeparator contained "/"
 syntax match clojureSymbol "\v%([a-zA-Z!$&*_+=|<.>?-]|[^\x00-\x7F])+%(:?%([a-zA-Z0-9!#$%&*_+=|'<.>/?-]|[^\x00-\x7F]))*[#:]@1<!" contains=clojureSymbolNs,clojureSymbolNsSeparator
 

--- a/syntax/clojure.vim
+++ b/syntax/clojure.vim
@@ -62,13 +62,16 @@ endif
 unlet! s:key
 delfunction s:syntax_keyword
 
+syntax match clojureKeywordNs contained "\v[^/ :']+\ze/"
+syntax match clojureKeywordNsSeparator contained "/"
+syntax match clojureKeywordNsColon contained "\v<:{1,2}"
 " Keywords are symbols:
 "   static Pattern symbolPat = Pattern.compile("[:]?([\\D&&[^/]].*/)?([\\D&&[^/]][^/]*)");
 " But they:
 "   * Must not end in a : or /
 "   * Must not have two adjacent colons except at the beginning
 "   * Must not contain any reader metacharacters except for ' and #
-syntax match clojureKeyword "\v<:{1,2}([^ \n\r\t()\[\]{}";@^`~\\/]+/)*[^ \n\r\t()\[\]{}";@^`~\\/]+:@1<!>"
+syntax match clojureKeyword "\v<:{1,2}([^ \n\r\t()\[\]{}";@^`~\\/]+/)*[^ \n\r\t()\[\]{}";@^`~\\/]+:@1<!>" contains=clojureKeywordNs,clojureKeywordNsSeparator,clojureKeywordNsColon
 
 syntax match clojureStringEscape "\v\\%([\\btnfr"]|u\x{4}|[0-3]\o{2}|\o{1,2})" contained
 
@@ -76,7 +79,9 @@ syntax region clojureString matchgroup=clojureStringDelimiter start=/"/ skip=/\\
 
 syntax match clojureCharacter "\v\\%(o%([0-3]\o{2}|\o{1,2})|u\x{4}|newline|tab|space|return|backspace|formfeed|.)"
 
-syntax match clojureSymbol "\v%([a-zA-Z!$&*_+=|<.>?-]|[^\x00-\x7F])+%(:?%([a-zA-Z0-9!#$%&*_+=|'<.>/?-]|[^\x00-\x7F]))*[#:]@1<!"
+syntax match clojureSymbolNs contained "\v[^/ :']+\ze/"
+syntax match clojureSymbolNsSeparator contained "/"
+syntax match clojureSymbol "\v%([a-zA-Z!$&*_+=|<.>?-]|[^\x00-\x7F])+%(:?%([a-zA-Z0-9!#$%&*_+=|'<.>/?-]|[^\x00-\x7F]))*[#:]@1<!" contains=clojureSymbolNs,clojureSymbolNsSeparator
 
 " NB. Correct matching of radix literals was removed for better performance.
 syntax match clojureNumber "\v<[-+]?%(%([2-9]|[12]\d|3[0-6])[rR][[:alnum:]]+|%(0\o*|0x\x+|[1-9]\d*)N?|%(0|[1-9]\d*|%(0|[1-9]\d*)\.\d*)%(M|[eE][-+]?\d+)?|%(0|[1-9]\d*)/%(0|[1-9]\d*))>"
@@ -162,11 +167,16 @@ syntax sync fromstart
 highlight default link clojureConstant                  Constant
 highlight default link clojureBoolean                   Boolean
 highlight default link clojureCharacter                 Character
-highlight default link clojureKeyword                   Keyword
 highlight default link clojureNumber                    Number
 highlight default link clojureString                    String
 highlight default link clojureStringDelimiter           String
 highlight default link clojureStringEscape              Character
+
+highlight default link clojureKeyword                   Keyword
+highlight default link clojureKeywordNsColon            clojureKeyword
+highlight default link clojureKeywordNs                 clojureKeyword
+
+highlight default link clojureSymbolNs                  clojureSymbol
 
 highlight default link clojureRegexp                    Constant
 highlight default link clojureRegexpDelimiter           Constant

--- a/syntax/clojure.vim
+++ b/syntax/clojure.vim
@@ -79,7 +79,7 @@ syntax region clojureString matchgroup=clojureStringDelimiter start=/"/ skip=/\\
 
 syntax match clojureCharacter "\v\\%(o%([0-3]\o{2}|\o{1,2})|u\x{4}|newline|tab|space|return|backspace|formfeed|.)"
 
-syntax match clojureSymbolNs contained "\v[^/\[\(\{ ]+\ze/"
+syntax match clojureSymbolNs contained "\v[^ \n\r\t()\[\]{}";@^`~\\\/'#]+\ze\/"
 syntax match clojureSymbolNsSeparator contained "/"
 syntax match clojureSymbol "\v%([a-zA-Z!$&*_+=|<.>?-]|[^\x00-\x7F])+%(:?%([a-zA-Z0-9!#$%&*_+=|'<.>/?-]|[^\x00-\x7F]))*[#:]@1<!" contains=clojureSymbolNs,clojureSymbolNsSeparator
 

--- a/syntax/clojure.vim
+++ b/syntax/clojure.vim
@@ -62,7 +62,7 @@ endif
 unlet! s:key
 delfunction s:syntax_keyword
 
-syntax match clojureKeywordNs contained "\v[^/: ']+[^/ ']*\ze/"
+syntax match clojureKeywordNs contained "\v[^ \n\r\t()\[\]{}";@^`~\\\/'#]+\ze\/"
 syntax match clojureKeywordNsSeparator contained "/"
 syntax match clojureKeywordNsColon contained "\v<:{1,2}"
 " Keywords are symbols:


### PR DESCRIPTION
This adds prefix matching to the keywords and symbols but not to namespaced functions (I may add this later, not sure how yet)

The default highlighting is not too obtrusive (it's possible to match symbol's and keyword's namespace but they're left to be the same as the item itself (symbol is white-on-white in this colorscheme as it's regarded to as Normal already)):

![image](https://user-images.githubusercontent.com/1641263/187664349-cbf37982-073c-49da-a46e-123920d42331.png)
