### PR TITLE
Detect .bb and .clj_kondo file extension as Clojure

### DIFF
--- a/after/ftdetect/clojure.vim
+++ b/after/ftdetect/clojure.vim
@@ -1,0 +1,3 @@
+if get(g:, 'clojure_detect_unofficial_exts', 1)
+    autocmd BufNewFile,BufRead {build,profile}.boot,*.bb,*.clj_kondo setlocal filetype=clojure
+endif

--- a/ftdetect/clojure.vim
+++ b/ftdetect/clojure.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *.clj,*.cljs,*.edn,*.cljx,*.cljc,{build,profile}.boot,*.bb,*.clj_kondo setlocal filetype=clojure
+autocmd BufNewFile,BufRead *.clj,*.cljs,*.edn,*.cljx,*.cljc setlocal filetype=clojure

--- a/ftdetect/clojure.vim
+++ b/ftdetect/clojure.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *.clj,*.cljs,*.edn,*.cljx,*.cljc,{build,profile}.boot setlocal filetype=clojure
+autocmd BufNewFile,BufRead *.clj,*.cljs,*.edn,*.cljx,*.cljc,{build,profile}.boot,*.bb,*.clj_kondo setlocal filetype=clojure

--- a/ftplugin/clojure.vim
+++ b/ftplugin/clojure.vim
@@ -69,7 +69,8 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
 	let b:browsefilter = "All Files\t*\n" .
 				\ "Clojure Files\t*.clj;*.cljc;*.cljs;*.cljx;*.bb;*.clj_kondo\n" .
 				\ "EDN Files\t*.edn\n" .
-				\ "Java Files\t*.java\n"
+				\ "Java Files\t*.java\n" .
+				\ "XML Files\t*.xml\n"
 	let b:undo_ftplugin .= ' | unlet! b:browsefilter'
 endif
 

--- a/ftplugin/clojure.vim
+++ b/ftplugin/clojure.vim
@@ -67,7 +67,7 @@ endif
 " Filter files in the browse dialog
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
 	let b:browsefilter = "All Files\t*\n" .
-				\ "Clojure Files\t*.clj;*.cljc;*.cljs;*.cljx\n" .
+				\ "Clojure Files\t*.clj;*.cljc;*.cljs;*.cljx;*.bb;*.clj_kondo\n" .
 				\ "EDN Files\t*.edn\n" .
 				\ "Java Files\t*.java\n"
 	let b:undo_ftplugin .= ' | unlet! b:browsefilter'


### PR DESCRIPTION
This should resolve issue #38.

I ran the Clojure program to update the syntax files but nothing was changed except the comment about the version of Java using with Clojure. I did have to make the `update-project!` function not private to run the function as specified in [contributiting guidelines](https://github.com/clojure-vim/clojure.vim/blob/bc3f1faf93ac47343b66b0e189990149a7fc0715/CONTRIBUTING.md).

I didn't test the *browsefilter* because I don't use Windows or GTK.

I ran `lein test` and got:
```
Ran 7 tests containing 272 assertions.
0 failures, 0 errors.
```
I installed my changes as a plugin for Vim 9.0.2142 on macOS Sequoia 15.0.1 on Apple Silicon (M3 2024 Macbook air). Editing files with extension *.bb* and *.clj_kondo* are detected as `clojure` files. The same is true with Neovim 0.10.2.

I did notice that in a file without a filename extension but a shebang line, the filetype isn't set to `clojure`.

Another thing that I noticed is that *.bb* is a recognized as a `bitbake` filetype so the associated *.vim* scripts are loaded as reported by `:scriptnames`. I'm not sure if that affects the syntax highlighting and/or indent as I'm not quite up-to-speed with Clojure syntax.